### PR TITLE
Add --express-mode to open packs instantaneously

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@ python3 ./main.py
 
 Optional args:
 
-- `--no-wait` (coming soon): remove all waits and "continue" prompts from pack opening
-  - Example: `python3 ./main.py --no-wait`
+- `--express-mode` or `-e`: open packs instantaneously by removing waits and "continue" prompts
+  - Example: `python3 ./main.py --express-mode` or `python3 ./main.py -e`

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import getopt
 import time
 import sys
 
@@ -8,6 +9,13 @@ from modules.pack import Pack
 from utils.fileio import load_expansions
 
 def main():
+    arguments = sys.argv[1:]
+    short_opts = "e"
+    long_opts = ["express-mode"]
+    selected_opts, vals = getopt.getopt(arguments, short_opts, long_opts)
+    flags = [key for key, val in selected_opts if val == '']
+    in_express_mode = "--express-mode" in flags or "-e" in flags
+
     all_expansions = load_expansions('./expansion-files/mythical-island.json')
 
     expansion = prompt_expansion_selection(all_expansions)
@@ -18,14 +26,15 @@ def main():
     num_packs = prompt_number_of_packs(expansion, all_expansions)
 
     sys.stdout.write(f"Opening {num_packs} packs of {expansion}!\n")
-    time.sleep(1.5)
+    if not in_express_mode:
+        time.sleep(1.5)
     collection = Collection()
     packs = [Pack(pack_type.name, pack_type.available, pack_type.pull_rates, pack_type.rare_pack_rate) for _ in range(num_packs)]
     for x, pack in enumerate(packs):
-        received = pack.open()
+        received = pack.open(instantaneous=in_express_mode)
         for card in received:
             collection.add(card)
-        if x < len(packs) - 1:
+        if x < len(packs) - 1 and not in_express_mode:
             input("\nPress any character to continue...")
 
     sys.stdout.write("Summary of final results:\n")

--- a/modules/pack.py
+++ b/modules/pack.py
@@ -27,26 +27,29 @@ class Pack:
         # normalize probabilities to sum to 1 (accounts for rounding error summing to 0.99999...)
         self.probs = utils.probability.normalize_probabilities(self.probs, axis=1)
 
-    def open(self):
+    def open(self, instantaneous):
         if self.unopened:
             sys.stdout.write("Opening pack!\n")
-            time.sleep(0.5)
+            if not instantaneous:
+                time.sleep(0.5)
             rare_pack_check = np.random.rand()
             if rare_pack_check < self.rare_pack_rate: # RARE PACK
                 for x in range(5):
                     sys.stdout.write(f"WOOWWWWW YOU GOT A RARE PACK!!! This only occurs {self.rare_pack_rate*100}% of the time!!\n")
                     card = np.random.choice(self.available, 1, replace=True, p=self.probs[5])
                     sys.stdout.write(f"Opened: {card}!\n")
-                    time.sleep(0.5)
+                    if not instantaneous:
+                        time.sleep(0.5)
                     self.cards.append(card)
             else: # REGULAR PACK
                 for x in range(5):
                     card = np.random.choice(self.available, 1, replace=True, p=self.probs[x])[0]
                     sys.stdout.write(f"Opened: {card}!\n")
-                    time.sleep(0.5)
+                    if not instantaneous:
+                        time.sleep(0.5)
                     self.cards.append(card)
 
-            sys.stdout.write(f"Summary: {str(self.cards)}\n")
+            sys.stdout.write(f"Summary: {str(self.cards)}\n\n")
             return self.cards
         else:
             sys.stderr.write("Can't open pack that has already been unsealed... (mitchell check your code, this shouldn't happen)\n")


### PR DESCRIPTION
Usage:
    - `python3 ./main.py --express-mode`
    - `python3 ./main.py -e`

Default mode is non-express mode. This means there is a half-second wait for each opened card and prompts to continue opening after each pack.