### PR TITLE
Rename --express-mode to --batch-mode to be more UNIX

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,11 +10,11 @@ from utils.fileio import load_expansions, save_collection
 
 def main():
     arguments = sys.argv[1:]
-    short_opts = "e"
-    long_opts = ["express-mode"]
+    short_opts = "b"
+    long_opts = ["batch-mode"]
     selected_opts, vals = getopt.getopt(arguments, short_opts, long_opts)
     flags = [key for key, val in selected_opts if val == '']
-    in_express_mode = "--express-mode" in flags or "-e" in flags
+    in_batch_mode = "--batch-mode" in flags or "-b" in flags
 
     all_expansions = load_expansions("genetic-apex.json", "mythical-island.json")
 
@@ -23,18 +23,18 @@ def main():
     num_packs, pack_type, expansion = prompt_number_of_packs(pack_type, expansion, all_expansions)
 
     sys.stdout.write(f"Opening {num_packs} packs of {expansion}!\n")
-    if not in_express_mode:
+    if not in_batch_mode:
         time.sleep(1.5)
     collection = Collection()
     rare_pack_count = 0
     packs = [Pack(pack_type.name, pack_type.available, pack_type.pull_rates, pack_type.rare_pack_rate) for _ in range(num_packs)]
     for x, pack in enumerate(packs):
-        received = pack.open(instantaneous=in_express_mode)
+        received = pack.open(instantaneous=in_batch_mode)
         if pack.is_rare:
             rare_pack_count += 1
         for card in received:
             collection.add(card)
-        if x < len(packs) - 1 and not in_express_mode:
+        if x < len(packs) - 1 and not in_batch_mode:
             input("\nPress any character to continue...")
 
     sys.stdout.write("Summary of final results:\n")


### PR DESCRIPTION
`-b` is commonly used to suppress prompts in UNIX commands (for "batch" processing). `-e` may be misinterpreted as passing extra arguments or commands.