### PR TITLE
If in release mode, find expansions at ./_internal/expansion-files

### DIFF
--- a/utils/fileio.py
+++ b/utils/fileio.py
@@ -15,7 +15,12 @@ def load_expansions(*args):
         @returns objects representing all expansion
     """
     expansions = []
-    current = Path(".")
+    if getattr(sys, 'frozen', False):
+        script_path = Path(os.path.dirname(sys.executable))
+        current = script_path / "_internal"
+    else:
+        current = Path(".")
+
     expansions_path = current / "expansion-files"
     for filename in args:
         full_path = expansions_path / filename


### PR DESCRIPTION
Using PyInstaller to include expansion files in release:
`python3 -m PyInstaller ./main.py -n ptcgp-sim --add-data "expansion-files/*.json:./expansion-files"`

This puts expansion files in `./_internal/expansion-files/`, but script was looking in `./expansion-files`